### PR TITLE
CheckBox size fixed

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -41,7 +41,11 @@ input:checked+p {
 
 input[type="checkbox"] {
   margin: 20px;
+  width: 20px;
+  height: 20px;
 }
+
+
 
 p {
   margin: 0;


### PR DESCRIPTION
# Check box size increased
checkbox size is too small compared to text
<div style="display: flex; justify-content: space-between;">
  <img width="375" alt="image" src="https://github.com/Pranavnk15/Todo-List/assets/89702867/35d5c144-671c-4d5a-9887-54aa6c97ce42">
  <img width="360" alt="image" src="https://github.com/Pranavnk15/Todo-List/assets/89702867/b0e732ca-3ce9-4163-b66c-337ac7982e3a">
</div>

